### PR TITLE
Fixed "unknown colour" error message

### DIFF
--- a/One Dark.tmTheme
+++ b/One Dark.tmTheme
@@ -780,7 +780,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>adb7c9</string>
+				<string>#adb7c9</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Hi,

One of the colours did not start with a hashtag which resulted in displaying an error message in Sublime Text's console: Unable to parse color value adb7c9 at Packages/User/SublimeLinter/One Dark (SL).tmTheme:unknown

Let me know if you have any questions.